### PR TITLE
Add random dRep test and fix test 2K_2 due to status

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/dRepDirectoryPage.ts
@@ -103,10 +103,7 @@ export default class DRepDirectoryPage {
 
   async sortDRep(option: string) {}
 
-  async sortAndValidate(
-    option: string,
-    validationFn: (p1: IDRep, p2: IDRep) => boolean
-  ) {
+  async getDRepsResponseFromApi(option: string): Promise<IDRep[]> {
     const responsePromise = this.page.waitForResponse((response) =>
       response.url().includes(`&sort=${option}`)
     );
@@ -114,7 +111,14 @@ export default class DRepDirectoryPage {
     await this.page.getByTestId(`${option}-radio`).click();
     const response = await responsePromise;
 
-    const dRepList: IDRep[] = (await response.json()).elements;
+    return (await response.json()).elements;
+  }
+
+  async sortAndValidate(
+    option: string,
+    validationFn: (p1: IDRep, p2: IDRep) => boolean
+  ) {
+    const dRepList = await this.getDRepsResponseFromApi(option);
 
     // API validation
     for (let i = 0; i <= dRepList.length - 2; i++) {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -2,21 +2,28 @@ import { setAllureEpic } from "@helpers/allure";
 import { skipIfNotHardFork } from "@helpers/cardano";
 import DRepDirectoryPage from "@pages/dRepDirectoryPage";
 import { expect, test } from "@playwright/test";
-import { DRepStatus } from "@types";
+import { DRepStatus, IDRep } from "@types";
 
 test.beforeEach(async () => {
   await setAllureEpic("2. Delegation");
   await skipIfNotHardFork();
 });
 
+enum SortOption {
+  Random = "Random",
+  RegistrationDate = "RegistrationDate",
+  VotingPower = "VotingPower",
+  Status = "Status",
+}
+
+const statusRank: Record<DRepStatus, number> = {
+  Active: 1,
+  Inactive: 2,
+  Retired: 3,
+};
+
 test("2K_2. Should sort DReps", async ({ page }) => {
   test.slow();
-
-  enum SortOption {
-    RegistrationDate = "RegistrationDate",
-    VotingPower = "VotingPower",
-    Status = "Status",
-  }
 
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();
@@ -33,10 +40,9 @@ test("2K_2. Should sort DReps", async ({ page }) => {
     (d1, d2) => d1.votingPower >= d2.votingPower
   );
 
-  await dRepDirectory.sortAndValidate(
-    SortOption.Status,
-    (d1, d2) => d1.status >= d2.status
-  );
+  await dRepDirectory.sortAndValidate(SortOption.Status, (d1, d2) => {
+    return statusRank[d1.status] <= statusRank[d2.status];
+  });
 });
 
 test("2O. Should load more DReps on show more", async ({ page }) => {

--- a/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
+++ b/tests/govtool-frontend/playwright/tests/2-delegation/delegation.spec.ts
@@ -45,6 +45,37 @@ test("2K_2. Should sort DReps", async ({ page }) => {
   });
 });
 
+test("2K_3. Should sort DReps randomly", async ({ page }) => {
+  const dRepDirectory = new DRepDirectoryPage(page);
+  await dRepDirectory.goto();
+
+  await dRepDirectory.sortBtn.click();
+
+  await page.getByTestId(`${SortOption.RegistrationDate}-radio`).click();
+
+  const dRepList1: IDRep[] = await dRepDirectory.getDRepsResponseFromApi(
+    SortOption.Random
+  );
+
+  await page.getByTestId(`${SortOption.RegistrationDate}-radio`).click();
+
+  const dRepList2: IDRep[] = await dRepDirectory.getDRepsResponseFromApi(
+    SortOption.Random
+  );
+
+  // Extract dRepIds from both lists
+  const dRepIdsList1 = dRepList1.map((dRep) => dRep.drepId);
+  const dRepIdsList2 = dRepList2.map((dRep) => dRep.drepId);
+
+  expect(dRepList1.length).toEqual(dRepList2.length);
+
+  const isOrderDifferent = dRepIdsList1.some(
+    (id, index) => id !== dRepIdsList2[index]
+  );
+
+  expect(isOrderDifferent).toBe(true);
+});
+
 test("2O. Should load more DReps on show more", async ({ page }) => {
   const dRepDirectory = new DRepDirectoryPage(page);
   await dRepDirectory.goto();


### PR DESCRIPTION
## List of changes

- Fix test 2K_2 by adding status ranking for validation
- Add test 2K_3 to sort dRep randomly

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
