### PR TITLE
hotfix: use getByText on receiving address and amount input field

### DIFF
--- a/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
+++ b/tests/govtool-frontend/playwright/lib/pages/proposalSubmissionPage.ts
@@ -60,10 +60,8 @@ export default class ProposalSubmissionPage {
   readonly metadataUrlInput = this.page.getByTestId("url-input");
   readonly motivationInput = this.page.getByTestId("motivation-input");
   readonly rationaleInput = this.page.getByTestId("rationale-input");
-  readonly receivingAddressInput = this.page.getByTestId(
-    "receiving-address-input"
-  );
-  readonly amountInput = this.page.getByTestId("amount-input");
+  readonly receivingAddressInput = this.page.getByText('Receiving stake address 1 *').first(); //BUG Incorrect testId
+  readonly amountInput = this.page.getByText('Amount 1 *').first(); //BUG Incorrect testId
   readonly closeDraftSuccessModalBtn = this.page.getByTestId("close-button");
 
   constructor(private readonly page: Page) {}


### PR DESCRIPTION
## List of changes

- Use getByText on receiving address and amount input field

## Checklist

- [related issue](https://github.com/IntersectMBO/govtool/issues/)
- [x] My changes generate no new warnings
- [x] My code follows the [style guidelines](https://github.com/IntersectMBO/govtool/tree/main/docs/style-guides) of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [changelog](https://github.com/IntersectMBO/govtool/blob/main/CHANGELOG.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
